### PR TITLE
Add draw event when board fills

### DIFF
--- a/src/Game.php
+++ b/src/Game.php
@@ -6,25 +6,42 @@ namespace TicTacToe;
 
 class Game
 {
-	private array $spaces = [];
-	private ?Mark $currentMark = null;
+        private array $spaces = [];
+        private ?Mark $currentMark = null;
+        private array $listeners = [];
 
-	public function place (Mark $mark, Position $position): void
-	{
-		if ($this->currentMark !== null) {
-			$this->currentMark->validateTurn($mark);
-		}
+        public function place (Mark $mark, Position $position): void
+        {
+                if ($this->currentMark !== null) {
+                        $this->currentMark->validateTurn($mark);
+                }
 
 		if (isset($this->spaces[$position->value])) {
 			throw new InvalidMove();
 		}
 
-		$this->spaces[$position->value] = $mark;
-		$this->currentMark = $mark;
-	}
+                $this->spaces[$position->value] = $mark;
+                $this->currentMark = $mark;
 
-	public static function new (): Game
-	{
-		return new Game();
-	}
+                if (count($this->spaces) === count(Position::cases())) {
+                        $this->gameOver();
+                }
+        }
+
+        public function attach (GameListener $listener): void
+        {
+                $this->listeners[] = $listener;
+        }
+
+        private function gameOver (): void
+        {
+                foreach ($this->listeners as $listener) {
+                        $listener->gameOver($this);
+                }
+        }
+
+        public static function new (): Game
+        {
+                return new Game();
+        }
 }

--- a/src/GameListener.php
+++ b/src/GameListener.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TicTacToe;
+
+interface GameListener
+{
+    public function gameOver(Game $game): void;
+}

--- a/test/GameOverTest.php
+++ b/test/GameOverTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use TicTacToe\Game;
+use TicTacToe\GameListener;
+use TicTacToe\Mark;
+use TicTacToe\Position;
+
+class GameOverTest extends TestCase
+{
+    #[Test]
+    function notifiesDrawWhenNoMovesAvailable(): void
+    {
+        $game = Game::new();
+
+        $listener = $this->createMock(GameListener::class);
+        $listener->expects($this->once())->method('gameOver')->with($this->identicalTo($game));
+        $game->attach($listener);
+
+        $mark = Mark::X;
+        foreach (Position::cases() as $position) {
+            $game->place($mark, $position);
+            $mark = $mark->not();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `GameListener` for draw events
- notify listeners when game board is full
- test that the draw event fires when no moves are left

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6866d4546b5483239ee8c424deb7d858